### PR TITLE
Support to InteractsWithPageFilters 

### DIFF
--- a/resources/views/components/component-container.blade.php
+++ b/resources/views/components/component-container.blade.php
@@ -53,7 +53,7 @@
                     $livewireComponent = $tabContainer->getComponent();
                 @endphp
                 @if ($livewireComponent)
-                    @livewire($livewireComponent, $tabContainer->getData() ?? [])
+                    @livewire($livewireComponent, $tabContainer->getData() ?? [], key($livewireComponent))
                 @endif
             @endif
         </div>

--- a/src/Concerns/Layouts/InteractsWithTab.php
+++ b/src/Concerns/Layouts/InteractsWithTab.php
@@ -80,7 +80,7 @@ trait InteractsWithTab
 
             if (is_array($tab)) {
                 if (! SimpleTabSchema::isValidArray($tab) && TabWidgetContentConfiguration::isValidArray($tab)) {
-                    $ab = TabWidgetContentConfiguration::parseFormArray($tab);
+                    $tab = TabWidgetContentConfiguration::parseFormArray($tab);
                 } else {
                     $tab = SimpleTabSchema::parseFormArray($tab);
                 }
@@ -120,7 +120,7 @@ trait InteractsWithTab
 
             } else {
                 throw new \InvalidArgumentException('Each tab must be an instance of '.Tab::class.' or a valid array configuration.');
-            }    
+            }
 
             $convertedTabs[] = $tab;
         }

--- a/src/Concerns/Layouts/InteractsWithTab.php
+++ b/src/Concerns/Layouts/InteractsWithTab.php
@@ -22,10 +22,20 @@ trait InteractsWithTab
 
     public function mountInteractsWithTab(): void
     {
+        $this->generateTabs();
+    }
+
+    private function generateTabs(): void
+    {
         $this->tabs = static::tabs($this->getTabs());
         if ($this instanceof HasTabs) {
             $this->tabs->livewire($this);
         }
+    }
+
+    public function rendering(): void
+    {
+        $this->generateTabs();
     }
 
     public static function tabs(Tabs $tabs): Tabs
@@ -70,7 +80,7 @@ trait InteractsWithTab
 
             if (is_array($tab)) {
                 if (! SimpleTabSchema::isValidArray($tab) && TabWidgetContentConfiguration::isValidArray($tab)) {
-                    $tab = TabWidgetContentConfiguration::parseFormArray($tab);
+                    $ab = TabWidgetContentConfiguration::parseFormArray($tab);
                 } else {
                     $tab = SimpleTabSchema::parseFormArray($tab);
                 }
@@ -110,7 +120,7 @@ trait InteractsWithTab
 
             } else {
                 throw new \InvalidArgumentException('Each tab must be an instance of '.Tab::class.' or a valid array configuration.');
-            }
+            }    
 
             $convertedTabs[] = $tab;
         }


### PR DESCRIPTION
This PR introduces support for using the InteractsWithPageFilters trait within the TabWidget component. With this enhancement, tabs can now respond dynamically to page-level filters, enabling more flexible and context-aware tab rendering.

With this improvement, it is possible to display several table widgets in tabs with them responding to page filters.
