### PR TITLE
Fix: Allow BackedEnum in HasIcon trait

### DIFF
--- a/src/Concerns/Components/HasIcon.php
+++ b/src/Concerns/Components/HasIcon.php
@@ -2,20 +2,21 @@
 
 namespace SolutionForest\TabLayoutPlugin\Concerns\Components;
 
+use BackedEnum;
 use Closure;
 
 trait HasIcon
 {
-    protected string|Closure|null $icon = null;
+    protected string|Closure|BackedEnum|null $icon = null;
 
-    public function icon(string|Closure|null $icon): static
+    public function icon(string|Closure|BackedEnum|null $icon): static
     {
         $this->icon = $icon;
 
         return $this;
     }
 
-    public function getIcon(): ?string
+    public function getIcon(): string|BackedEnum|null
     {
         return $this->evaluate($this->icon);
     }


### PR DESCRIPTION
This PR allows BackedEnum as `icon()` argument, allows to use `Heroicon` enum or any other icon extension, instead of just string.